### PR TITLE
Run android test on Linux runner.

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -48,7 +48,7 @@ jobs:
 
   android-test:
     needs: build
-    runs-on: macos-13
+    runs-on: ubuntu-latest
     name: android-test (api ${{ matrix.emulator.api-level }})
     strategy:
       fail-fast: false
@@ -66,6 +66,11 @@ jobs:
         with:
           name: libs
           path: android_test/app/libs/
+      - name: Enable KVM group perms
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
       - uses: actions/setup-java@v4
         with:
           java-version: ${{ env.JAVA_VERSION }}


### PR DESCRIPTION
This will reduce the time needed for testing.

https://github.blog/changelog/2023-02-23-hardware-accelerated-android-virtualization-on-actions-windows-and-linux-larger-hosted-runners/